### PR TITLE
fix: configure netlify dev port to match vite server (4174)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,12 @@
   command = "npm run build"
   publish = "dist"
 
+[dev]
+  framework = "#custom"
+  command = "npm run dev"
+  targetPort = 4174
+  port = 8888
+
 [functions]
   directory = "netlify/functions"
 


### PR DESCRIPTION
Adds [dev] section to netlify.toml so netlify dev proxies the Vite dev server on port 4174 instead of waiting for the default 5173.

https://claude.ai/code/session_01Bj3diUsqmgCQ8Rtdoa2R8P